### PR TITLE
Fix crate name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Based on latest UI sketches and feedback:
 
 ## 4. Implementation Plan
 
-### 4.1 Core Library (`box_planner-core`)  
+### 4.1 Core Library (`box_planner_core`)
 - **Data models** in `src/model.rs` (derive `Serialize`/`Deserialize`).  
 - **CSV I/O** via the [`csv`](https://crates.io/crates/csv) and [`serde`](https://crates.io/crates/serde) crates.  
 - **In-memory state**: `Vec<Employee>` and `GridState` structs.  


### PR DESCRIPTION
## Summary
- correct the crate reference in the Implementation Plan section

## Testing
- `cargo test` *(fails: failed to download dependency due to 403)*

------
https://chatgpt.com/codex/tasks/task_e_68431c299e58832b958acc751f826412